### PR TITLE
Fix date visualization

### DIFF
--- a/src/components/BondSetByChart.tsx
+++ b/src/components/BondSetByChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import * as XLSX from 'xlsx';
+import { formatDate } from '../helpers/utils';
 
 ChartJS.register(
   CategoryScale,
@@ -50,15 +51,7 @@ const BondSetByChart: React.FC = () => {
       });
   }, []);
 
-  const formatDate = (dateStr: string): string => {
-    // Parse the date string directly to avoid timezone conversion issues
-    const [year, month] = dateStr.split('-');
-    const date = new Date(parseInt(year), parseInt(month) - 1, 1);
-    return date.toLocaleDateString('en-US', { 
-      year: 'numeric', 
-      month: 'short' 
-    });
-  };
+  
 
   const categoryLabels = {
     bond_set_by_IJ: 'Immigration Judge',

--- a/src/components/BondSetByChart.tsx
+++ b/src/components/BondSetByChart.tsx
@@ -51,7 +51,9 @@ const BondSetByChart: React.FC = () => {
   }, []);
 
   const formatDate = (dateStr: string): string => {
-    const date = new Date(dateStr);
+    // Parse the date string directly to avoid timezone conversion issues
+    const [year, month] = dateStr.split('-');
+    const date = new Date(parseInt(year), parseInt(month) - 1, 1);
     return date.toLocaleDateString('en-US', { 
       year: 'numeric', 
       month: 'short' 

--- a/src/components/ICEBookOutsChart.tsx
+++ b/src/components/ICEBookOutsChart.tsx
@@ -59,7 +59,9 @@ const ICEBookOutsChart: React.FC = () => {
   }, []);
 
   const formatDate = (dateStr: string): string => {
-    const date = new Date(dateStr);
+    // Parse the date string directly to avoid timezone conversion issues
+    const [year, month] = dateStr.split('-');
+    const date = new Date(parseInt(year), parseInt(month) - 1, 1);
     return date.toLocaleDateString('en-US', { 
       year: 'numeric', 
       month: 'short' 

--- a/src/components/ICEBookOutsChart.tsx
+++ b/src/components/ICEBookOutsChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import * as XLSX from 'xlsx';
+import { formatDate } from '../helpers/utils';
 
 ChartJS.register(
   CategoryScale,
@@ -57,16 +58,7 @@ const ICEBookOutsChart: React.FC = () => {
         console.error('Error loading data:', error);
       });
   }, []);
-
-  const formatDate = (dateStr: string): string => {
-    // Parse the date string directly to avoid timezone conversion issues
-    const [year, month] = dateStr.split('-');
-    const date = new Date(parseInt(year), parseInt(month) - 1, 1);
-    return date.toLocaleDateString('en-US', { 
-      year: 'numeric', 
-      month: 'short' 
-    });
-  };
+  
 
   const categoryLabels = {
     release_to_removed: 'Release to Remove (Deported)',

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a UTC date string into a readable string in the format 'Month YYYY'
+ *
+ * @param {string} dateStr - The UTC date string to format.
+ * @returns {string} - The formatted date string.
+ */
+
+export const formatDate = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('en-US', { 
+    year: 'numeric', 
+    month: 'short',
+    timeZone: 'UTC' // Ignore system's time zone so you get the date as is provided by the source.
+  });
+};


### PR DESCRIPTION
Dates on chart were of previous month instead of month in data.json.  I think it was because it's using the local time conversion and the server is in a different time zone.  So forcing the date formatting to assume it's in UTC.